### PR TITLE
Fix namespace bug in ExceptionHandler

### DIFF
--- a/src/Handler/ExceptionHandler.php
+++ b/src/Handler/ExceptionHandler.php
@@ -2,11 +2,11 @@
 
 namespace MmsApiClient\Handler;
 
-use MMS\MmsApiClient\Exceptions\UnauthorizedException;
-use MMS\MmsApiClient\Exceptions\NotFoundException;
-use MMS\MmsApiClient\Exceptions\BadRequestException;
-use MMS\MmsApiClient\Exceptions\ServerException;
-use MMS\MmsApiClient\Exceptions\GenericApiException;
+use MmsApiClient\Exceptions\UnauthorizedException;
+use MmsApiClient\Exceptions\NotFoundException;
+use MmsApiClient\Exceptions\BadRequestException;
+use MmsApiClient\Exceptions\ServerException;
+use MmsApiClient\Exceptions\GenericApiException;
 
 class ExceptionHandler
 {

--- a/tests/MmsApiClientTest.php
+++ b/tests/MmsApiClientTest.php
@@ -2,9 +2,6 @@
 
 use PHPUnit\Framework\TestCase;
 use MmsApiClient\MmsApiClient;
-use Symfony\Component\HttpClient\MockHttpClient;
-use Symfony\Contracts\HttpClient\ResponseInterface;
-use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 
 class MmsApiClientTest extends TestCase
 {
@@ -12,15 +9,11 @@ class MmsApiClientTest extends TestCase
 
     protected function setUp(): void
     {
-        // Mock the HTTP client to avoid actual API calls
-        $mockResponse = $this->createMock(ResponseInterface::class);
-        $mockResponse->method('toArray')->willReturn(['status' => 'success', 'data' => []]);
-
-        $mockHttpClient = $this->createMock(MockHttpClient::class);
-        $mockHttpClient->method('request')->willReturn($mockResponse);
-
-        // Create a mock API client with the mocked HTTP client
-        $this->apiClient = new MmsApiClient('https://demoapi.mms-portal.eu/index.php/MmsApi/v1', 'your-bearer-token', $mockHttpClient);
+        // Instantiate the client with a sample URL and token
+        $this->apiClient = new MmsApiClient(
+            'https://demoapi.mms-portal.eu/index.php/MmsApi/v1',
+            'your-bearer-token'
+        );
     }
 
     public function testClientInitialization()


### PR DESCRIPTION
## Summary
- fix invalid exception namespaces in ExceptionHandler
- update test to reflect current API client constructor

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6880df1299608327a05a1c4e5a0a794f